### PR TITLE
Rechtschreibfehler in Bildreferenz

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,7 @@ Schau dir [[Internetseite 2-&gt;Internetseite 2]] an.
 Sie dir diese Internetseiten an: 
 [[Internetseite 1 -&gt;Internetseite 3]] 
 [[Internetseite 2 -&gt;Internetseite 4]] </tw-passagedata><tw-passagedata pid="4" name="Internetseite 1" tags="" position="221,242" size="100,100">Möchtest du diese Internetseite wählen?
-&lt;img src='img/exedia.de.png'  width= &quot;500&quot; heigth=&quot;300&quot;&gt; 
+&lt;img src='img/expedia.de.png'  width= &quot;500&quot; heigth=&quot;300&quot;&gt; 
 [[Ja-&gt;Falsche Entscheidung 1]]
 [[Nein-&gt;Flug buchen]] </tw-passagedata><tw-passagedata pid="5" name="Internetseite 2" tags="" position="367,245" size="100,100">Möchtest du diese Internetseite wählen?
 &lt;img src='img/flüge.de.png' width= &quot;500&quot; heigth=&quot;300&quot;&gt;  


### PR DESCRIPTION
Die 'Anführungszeichen' scheinen es ja doch gelöst zu haben, der Build der aktualisierten Seite hat wohl nur etwas länger gedauert.
Das eine Bild hat noch immer nicht geladen, weil dort fälschlicherweise Exedia geschrieben wurde.